### PR TITLE
fix: implicit errors introduced by adding metrics for other segment types

### DIFF
--- a/pytrendy/io/plot_pytrendy.py
+++ b/pytrendy/io/plot_pytrendy.py
@@ -111,7 +111,7 @@ def plot_pytrendy(df: pd.DataFrame, value_col: str, segments_enhanced: list[dict
         ax.fill_between(df.index[mask], ymin, ymax, color=color, alpha=0.4)
         
         # Add ranking if up/down trend
-        if 'change_rank' in seg:
+        if 'change_rank' in seg and seg['direction'] in ['Up', 'Down']:
             mid_date = start + (end - start) / 2
             y_pos = ymax - (ymax - ymin) * 0.05
             ax.text(mid_date, y_pos, str(seg['change_rank']), fontsize=12,

--- a/pytrendy/io/results_pytrendy.py
+++ b/pytrendy/io/results_pytrendy.py
@@ -23,6 +23,8 @@ class PyTrendyResults:
                 List of dictionaries representing individual trend segments.
         """
         self.segments = segments
+        self.trend_segments = [seg for seg in self.segments if 'trend_class' in seg] # Get segments that are trends (exclude flats and noise)
+        
         self.set_best()
         self.set_df()
         self.set_summary()
@@ -35,10 +37,10 @@ class PyTrendyResults:
             - Identifies the best trend segment based on steepness and duration.
             - The segment with the lowest `change_rank` is selected as the best.
         """
-        if len(self.segments) == 0 or not any('change_rank' in segment for segment in self.segments):
+        if len(self.trend_segments) == 0:
             self.best = None
             return
-        self.best = min(self.segments, key=lambda x: x.get('change_rank', math.inf))
+        self.best = min(self.trend_segments, key=lambda x: x.get('change_rank', math.inf))
 
     def set_summary(self) -> None:
         """
@@ -52,21 +54,25 @@ class PyTrendyResults:
         # Exit if nothing to report on
         if len(self.segments) == 0:
             summary['df'] = pd.DataFrame()
-            return
+            return        
 
+        # Count the number of segments per direction type (Up, Down, Flat, Noise)
         direction_counts = Counter(seg["direction"] for seg in self.segments)
         summary["direction_counts"] = dict(direction_counts)
         
-        trend_class_counts = Counter(seg["trend_class"] for seg in self.segments if "trend_class" in seg)
+        # Count number of segments per trend classs (abrupt, gradual)
+        trend_class_counts = Counter(seg["trend_class"] for seg in self.trend_segments)
         summary["trend_class_counts"] = dict(trend_class_counts)
 
-        changes = [seg.get("total_change", 0) for seg in self.segments if "total_change" in seg]
+        # Get array of total change from trends and get max (best) total change
+        changes = [seg.get("total_change", 0) for seg in self.trend_segments]
         summary['highest_total_change'] = np.max(changes) if len(changes) > 0 else None
 
         # Set summary df (without extra details)
         df = pd.DataFrame(self.segments)
-        cols = ['time_index', 'direction', 'start', 'end', 'days']
-        if len(changes) > 1: cols += ['total_change', 'change_rank', 'trend_class']
+        cols = ['time_index', 'direction', 'start', 'end', 'days', 'total_change', 'change_rank']
+        if len(changes) > 1:  #  only include trend_class if atleast one trend exists
+            cols += ['trend_class']
         df = df[cols]
 
         df = df.set_index('time_index')

--- a/pytrendy/io/results_pytrendy.py
+++ b/pytrendy/io/results_pytrendy.py
@@ -54,7 +54,7 @@ class PyTrendyResults:
         # Exit if nothing to report on
         if len(self.segments) == 0:
             summary['df'] = pd.DataFrame()
-            return        
+            return
 
         # Count the number of segments per direction type (Up, Down, Flat, Noise)
         direction_counts = Counter(seg["direction"] for seg in self.segments)

--- a/pytrendy/post_processing/segments_analyse.py
+++ b/pytrendy/post_processing/segments_analyse.py
@@ -16,7 +16,7 @@ def analyse_segments(df: pd.DataFrame, value_col: str, segments: list[dict]) -> 
 
     Metrics added include:
     
-    - Absolute and percent change (based on min/max values)
+    - Absolute and percent change (based on start/end values)
 
     - Duration in days
 
@@ -47,25 +47,10 @@ def analyse_segments(df: pd.DataFrame, value_col: str, segments: list[dict]) -> 
         df_segment = df.loc[segment['start']:segment['end']]
 
         # Calculate absolute and relative change from first point to last point of trend.
-        # (Using min/max instead of first/last to be more robust to noise.)
-        val_min = df_segment[value_col].min()
-        val_max = df_segment[value_col].max()
-        if segment['direction'] == 'Up':  # max - min
-            segment_enhanced['change'] = float(val_max - val_min)
-            segment_enhanced['pct_change'] = (
-                float(val_max / val_min - 1) if val_min != 0 else np.nan
-            )
-        elif segment['direction'] == 'Down':  # min - max
-            segment_enhanced['change'] = float(val_min - val_max)
-            segment_enhanced['pct_change'] = (
-                float(val_min / val_max - 1) if val_max != 0 else np.nan
-            )
-        # I think this should capture all other segment types
-        else:
-            abs_change = float(abs(val_max - val_min))
-            segment_enhanced['change'] = abs_change
-            mean_val = df_segment[value_col].mean()
-            segment_enhanced['pct_change'] = (float(abs_change / mean_val * 100) if mean_val != 0 else np.nan)
+        val_start = df_segment[value_col].iloc[0]
+        val_end = df_segment[value_col].iloc[-1]
+        segment_enhanced['change'] = float(val_end - val_start)
+        segment_enhanced['pct_change'] = (float(val_end / val_start - 1) if val_start != 0 else np.nan)
 
         # Calculate days & cumulative total change
         days = (pd.to_datetime(segment['end']) - pd.to_datetime(segment['start'])).days

--- a/pytrendy/post_processing/segments_analyse.py
+++ b/pytrendy/post_processing/segments_analyse.py
@@ -88,7 +88,7 @@ def analyse_segments(df: pd.DataFrame, value_col: str, segments: list[dict]) -> 
 
     # Rank change, by steepest to shallowest change
     sorted_segments = sorted(segments_enhanced, key=lambda x: abs(x.get('total_change', 0)), reverse=True)
-    sorted_trends = [seg for seg in sorted_segments if 'total_change' in seg]
+    sorted_trends = [seg for seg in sorted_segments]
     for i, seg in enumerate(sorted_trends):
         j = seg['time_index'] - 1
         segments_enhanced[j]['change_rank'] = int(i+1)

--- a/pytrendy/post_processing/segments_refine/artifact_cleanup.py
+++ b/pytrendy/post_processing/segments_refine/artifact_cleanup.py
@@ -311,11 +311,11 @@ def clean_artifacts(df: pd.DataFrame, value_col: str, segments_refined: list[dic
         # Reclassify as noise if either edge cases met
         if too_noisy or (is_abrupt_near_noise and not trend_ends_too_close) or is_small_gradual_in_noise:
             segment['direction'] = 'Noise' 
-            segment['trend_class'] = 'noise'
+            if 'trend_class' in segment: del segment['trend_class']
 
         if trend_ends_too_close or trend_too_small or trend_too_flat:
             segment['direction'] = 'Flat' 
-            segment['trend_class'] = 'flat'
+            if 'trend_class' in segment: del segment['trend_class']
         
         segments_refined.append(segment)
 

--- a/pytrendy/post_processing/segments_refine/trend_classify.py
+++ b/pytrendy/post_processing/segments_refine/trend_classify.py
@@ -75,13 +75,4 @@ def classify_trends(df: pd.DataFrame, value_col: str, segments: list[dict]) -> l
         if segment_length < 3:
             segments_classified[i]['trend_class'] = 'abrupt'
 
-    for segment in segments_classified:
-        if 'trend_class' not in segment:
-            if segment['direction'] == 'Flat':
-                segment['trend_class'] = 'flat'
-            elif segment['direction'] == 'Noise':
-                segment['trend_class'] = 'noise'
-            else:
-                segment['trend_class'] = 'unknown'
-                
     return segments_classified


### PR DESCRIPTION
This PR fixes implicit errors introduced by instructions from issue #61, targetting draft PR #88 

My main process was branching off from your first commit in the branch, and debugging each of the failed errors step by step to understand the issue. The main culprit was as I suspected, spaghetti code: 

![image](https://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/1816Filipino_spaghetti_03.jpg/1280px-1816Filipino_spaghetti_03.jpg)

Spaghetti code conditions in `ResultsPytrendy`  had summary logic specific to trends that needed to be updated after `total_change` logic was generalised. A lot of things broke cause the conditions depended heavily on `total_change` to make assumptions on whether segments were trends, expecting `trend_class` as an existing key. The intended logic should still be that `trend_class` only exists for trends. But everything else should be generalised.

> Side note: There is another issue focusing on refactoring all the smelly spaghetti in the codebase, with Ruff #50 . This will start the base integration of integrating ruff checks, and slowly slowly, PR by PR, module by module, we we clean it all. Results PyTrendy could be a good starting point.

My main changes are grouped below:

---

### Essential Updates for Test Failures

These now bring the tests passing back to 100%. This was tested locally. 

(link to respective git commit in the blue subheaders below)

#### [Results PyTrendy Fixes](https://github.com/RussellSB/pytrendy/pull/89/commits/79ed06231c98952eee2eed00b11564ae1e77dd2d)

* Introduced a new attribute `trend_segments` in `ResultsPytrendy` to filter segments that have a `trend_class`, ensuring that only actual trend segments (excluding flats and noise) are considered for trend-related summaries.
* Updated the logic in `set_best` to select the best trend segment only from `trend_segments`.
* Modified the summary statistics in `set_summary` to count and aggregate only trend segments for metrics like trend class counts and highest total change, and adjusted the summary DataFrame columns accordingly.

#### [Plot Pytrendy Fixes](https://github.com/RussellSB/pytrendy/pull/89/commits/0c952792f08b23342db97b4684c187157c4c43ae)

* Updated the plotting logic in `plot_pytrendy` to only add ranking labels for segments that are both ranked and have a direction of 'Up' or 'Down', preventing irrelevant labels for other segment types.
* A deliberate choice so plots only show change rank for ups and downs, even though they all have it now. In hindsight this is a more reasonable decision than updating all the pytest-mpl plots, as it avoids me having to update things like all the GIFs in the docs for this minor change.

#### [Reverting Extra File Changes](https://github.com/RussellSB/pytrendy/pull/89/commits/057f78c9a2196f800ae08ba19ae3416477a5a8eb)

- Noticed tests_plotting failing again after merge conflict resolution to target branch. 
- Errors were introduced from target branch's extra edits on sensitive post processing logic. Changes were located in modules `trend_classify` and `artifact_cleanup`. Now reverted and tests back at 100%.
- It made test_plotting treat segments as trends when they shouldnt based on populated `trend_class`. 
- It was a good attempt with minimal context, but this wasn't the source of the problem, it was the above two points. Again partly my own issue of having some implicit conditions sprinkled around the place. Will get better with solid code refactoring with Ruff.

---

### Extra Cleanup

In the spirit of removing friction from smelly code, I refactored the **relative change logic** by simplifying it Occam's Razor style. I thought about this more since we last spoke about it.

I initially made this specific logic when spike handling wasn't as robust in pytrendy. It's come a long way since, and this isn't really relevant anymore. I'm just redoing it to simply calc rel change from start to end point, fullstop. This generalises well across all segment types, and doesn't break any tests.

#### [Simplified Relative Change Calculation](https://github.com/RussellSB/pytrendy/pull/89/commits/5e9e4c42230b1a0b01bcb3b71d53d9c79bf7c686)

* Changed the calculation of absolute and percent change in `analyse_segments` to use the start and end values of each segment, rather than the min and max.
* Updated the docstring documentation in `analyse_segments` to reflect that change metrics are now based on start/end values instead of min/max.