### PR TITLE
chore(deps): pin matplotlib==3.10.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "numpy",
     "pandas",
     "scipy",
-    "matplotlib"
+    "matplotlib==3.10.8"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Resolves PR #138 's failed test workflow run: https://github.com/RussellSB/pytrendy/actions/runs/27905851316/job/82574865555?pr=138

Had nothing to do with pytrendy code, but matplotlib updated to a version where rendering was silently affected in my codebase. Hence when pytest mpl compares images, it would fail with the latest version.

Pinning to working version as a deterministic solution. 
Matplotlib does not need to be the latest and greatest anyways, and this is only for [dev] requirements for testing, not user-facing requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated matplotlib dependency to a pinned version for improved stability and consistency across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->