### PR TITLE
ci(whats-new): migrate docs generator from GitHub Models to OpenCode Kimi K2.7-code

### DIFF
--- a/.github/workflows/whats-new.yaml
+++ b/.github/workflows/whats-new.yaml
@@ -10,7 +10,7 @@ name: What's New Generator
 # ─────────────────────────────────────────────────────────────────────────────
 # • Resolve release metadata from release events, dispatch inputs, or the Release workflow run.
 # • Parse release notes (or fall back to CHANGELOG.md).
-# • Call the GitHub Models API (GPT-4.1) to generate a user-friendly entry.
+# • Call OpenCode (opencode-go/kimi-k2.7-code) to generate a user-friendly entry.
 # • Prepend the new entry into docs/whats-new.md.
 # • Open a PR back to the release branch (develop or main) for review.
 # • On main: also open a follow-up PR to sync the page back to develop.
@@ -53,7 +53,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      models: read
 
     steps:
       # ── 1. Resolve metadata ─────────────────────────────────────────────────
@@ -144,10 +143,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      # ── 4. Run the agentic generator ────────────────────────────────────────
+      # ── 4. Install OpenCode CLI ─────────────────────────────────────────────
+      - name: Install OpenCode CLI
+        if: steps.meta.outputs.skip != 'true'
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      # ── 5. Run the agentic generator ────────────────────────────────────────
       - name: Generate What's New entry
         if: steps.meta.outputs.skip != 'true'
         env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/kimi-k2.7-code' }}
+          OPENCODE_PERMISSION: '{"bash": "deny", "edit": "deny", "webfetch": "deny", "websearch": "deny", "external_directory": "deny", "task": "deny"}'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.meta.outputs.tag }}
           RELEASE_NAME: ${{ steps.meta.outputs.name }}
@@ -175,8 +182,8 @@ jobs:
             after the `${{ steps.meta.outputs.tag }}` release was published.
 
             ### What changed
-            - A new entry was prepended to `docs/whats-new.md` using the GitHub Models API
-              (`gpt-4.1`) to summarise the release notes in a user-friendly way.
+            - A new entry was prepended to `docs/whats-new.md` using **OpenCode**
+              (`opencode-go/kimi-k2.7-code`) to summarise the release notes in a user-friendly way.
 
             ### Review checklist
             - [ ] The generated content is accurate and user-friendly.
@@ -205,7 +212,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      models: read
 
     steps:
       - name: Checkout develop
@@ -219,8 +225,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install OpenCode CLI
+        run: curl -fsSL https://opencode.ai/install | bash
+
       - name: Re-generate What's New for develop (reframe as stable)
         env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/kimi-k2.7-code' }}
+          OPENCODE_PERMISSION: '{"bash": "deny", "edit": "deny", "webfetch": "deny", "websearch": "deny", "external_directory": "deny", "task": "deny"}'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.generate-whats-new.outputs.tag }}
           RELEASE_NAME: ${{ needs.generate-whats-new.outputs.name }}

--- a/.github/workflows/whats-new.yaml
+++ b/.github/workflows/whats-new.yaml
@@ -146,7 +146,9 @@ jobs:
       # ── 4. Install OpenCode CLI ─────────────────────────────────────────────
       - name: Install OpenCode CLI
         if: steps.meta.outputs.skip != 'true'
-        run: curl -fsSL https://opencode.ai/install | bash
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          opencode --version
 
       # ── 5. Run the agentic generator ────────────────────────────────────────
       - name: Generate What's New entry
@@ -226,7 +228,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install OpenCode CLI
-        run: curl -fsSL https://opencode.ai/install | bash
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          opencode --version
 
       - name: Re-generate What's New for develop (reframe as stable)
         env:

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -102,8 +102,9 @@ Four updates in v1.2.0: an agentic docs generator, a new noise toggle, and two f
     ([`whats-new.yaml`](https://github.com/RussellSB/pytrendy/blob/main/.github/workflows/whats-new.yaml))
     fires automatically whenever a GitHub Release is published. It invokes
     [`scripts/generate_whats_new.py`](https://github.com/RussellSB/pytrendy/blob/main/scripts/generate_whats_new.py),
-    which calls the **GitHub Models API** (GPT-4.1) to write a user-friendly What's New entry
-    from the release notes, then opens a pull request for review.
+    which calls **OpenCode** (`opencode-go/kimi-k2.7-code`) to write a user-friendly What's New entry
+    from the release notes, then opens a pull request for review. (Previously powered by the
+    GitHub Models API / GPT-4.1.)
     Introduced: [#120](https://github.com/RussellSB/pytrendy/pull/120)
 
     Key behaviours:

--- a/scripts/generate_whats_new.py
+++ b/scripts/generate_whats_new.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Generate or update docs/whats-new.md using the GitHub Models API (GPT-5).
+"""Generate or update docs/whats-new.md using OpenCode (opencode-go/kimi-k2.7-code).
 
 The script:
   1. Reads the latest release notes (from RELEASE_BODY, then GitHub Releases API by
      tag, then CHANGELOG.md).
-  3. Calls the GitHub Models API (openai/gpt-4.1) to produce a user-friendly
+  2. Calls OpenCode (opencode-go/kimi-k2.7-code) to produce a user-friendly
      What's New section in MkDocs-compatible Markdown.
   3. Prepends the new section into docs/whats-new.md between the sentinel
      comment markers, preserving the rest of the file.
@@ -27,8 +27,12 @@ Agent instructions (run before each refresh):
 
 Environment variables
 ---------------------
-GITHUB_TOKEN   – required; used to authenticate against the GitHub Models API.
-RELEASE_TAG    – the semantic-release tag (e.g. "v1.2.0" or "v1.2.0-dev.1").
+OPENCODE_API_KEY – required; authenticates against the OpenCode API.
+OPENCODE_MODEL   – optional; model ID passed to `opencode run` (default:
+                   "opencode-go/kimi-k2.7-code").
+GITHUB_TOKEN     – required; used for the GitHub Releases API fallback and by the
+                   workflow to open pull requests.
+RELEASE_TAG      – the semantic-release tag (e.g. "v1.2.0" or "v1.2.0-dev.1").
 RELEASE_NAME   – human-readable release title.
 RELEASE_BODY   – raw Markdown body of the GitHub Release (release notes).
 IS_PRERELEASE  – "true" / "false"; controls the "Coming in…" vs "Released in…" framing.
@@ -40,6 +44,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import sys
 import textwrap
 import urllib.error
@@ -62,8 +67,7 @@ CONTENT_END = "<!-- WHATS_NEW_CONTENT_END -->"
 NOTE_START = "<!-- WHATS_NEW_NOTE_START -->"
 NOTE_END = "<!-- WHATS_NEW_NOTE_END -->"
 
-GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions"
-MODEL = "openai/gpt-4.1"
+DEFAULT_OPENCODE_MODEL = "opencode-go/kimi-k2.7-code"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -156,8 +160,8 @@ def _resolve_raw_notes(tag: str, release_body: str, token: str) -> str:
     return _fetch_release_body_from_github(tag, token) or _read_changelog_section(tag)
 
 
-def _call_github_models(prompt: str, token: str) -> str | None:
-    """Call the GitHub Models API (Claude Sonnet 4.6) and return the generated text, or None on failure."""
+def _call_opencode(prompt: str, model: str) -> str | None:
+    """Call the OpenCode CLI and return the generated text, or None on failure."""
     system = textwrap.dedent("""\
         You are a technical writer for PyTrendy, a Python library for time-series trend
         detection. Your task is to turn raw CHANGELOG / release-note Markdown into a
@@ -183,7 +187,7 @@ def _call_github_models(prompt: str, token: str) -> str | None:
           For bug fixes, always label with version numbers: `Before — vX.Y.Z` (the last
           stable release before the fix) and `After — vX.Y.Z` (the release introducing
           the fix). For feature toggles or configuration comparisons, a short descriptive
-          label (e.g. `Before — \`avoid_noise=True\` (default)`) is acceptable instead.
+          label (e.g. `Before — \\`avoid_noise=True\\` (default)`) is acceptable instead.
         - Group small patch releases (1–2 minor fixes each) into a single combined section
           rather than giving each its own heading.
         - Reference issue or PR numbers from the CHANGELOG where available (e.g. `[#12](url)`).
@@ -262,34 +266,35 @@ def _call_github_models(prompt: str, token: str) -> str | None:
         ---
     """)
 
-    payload = {
-        "model": MODEL,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": prompt},
-        ],
-        "max_tokens": 4000,
-        "temperature": 0.5,
-    }
-
-    req = urllib.request.Request(
-        GITHUB_MODELS_URL,
-        data=json.dumps(payload).encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2026-03-10",
-        },
-        method="POST",
+    env = os.environ.copy()
+    env.setdefault(
+        "OPENCODE_PERMISSION",
+        '{"bash": "deny", "edit": "deny", "webfetch": "deny", "websearch": "deny", '
+        '"external_directory": "deny", "task": "deny"}',
     )
 
+    full_prompt = system + "\n\n" + prompt
+
     try:
-        with urllib.request.urlopen(req, timeout=90) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-            return data["choices"][0]["message"]["content"].strip()
-    except (urllib.error.URLError, KeyError, json.JSONDecodeError, TimeoutError) as exc:
-        print(f"[whats-new] GitHub Models API unavailable: {exc}", file=sys.stderr)
+        result = subprocess.run(
+            ["opencode", "run", "-m", model],
+            input=full_prompt,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            env=env,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(
+                f"[whats-new] OpenCode CLI failed (exit {result.returncode}):",
+                file=sys.stderr,
+            )
+            print(result.stderr, file=sys.stderr)
+            return None
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        print(f"[whats-new] OpenCode CLI unavailable: {exc}", file=sys.stderr)
         return None
 
 
@@ -350,15 +355,17 @@ def _build_section(
     tag: str,
     raw_notes: str,
     is_prerelease: bool,
-    token: str,
 ) -> str:
     """Return the full Markdown block for one release (without top-level heading)."""
-    if not token:
+    api_key = _env("OPENCODE_API_KEY")
+    if not api_key:
         print(
-            "[whats-new] Error: GITHUB_TOKEN is not set. Cannot call the GitHub Models API.",
+            "[whats-new] Error: OPENCODE_API_KEY is not set. Cannot call OpenCode.",
             file=sys.stderr,
         )
         sys.exit(1)
+
+    model = _env("OPENCODE_MODEL", DEFAULT_OPENCODE_MODEL)
 
     prompt = textwrap.dedent(f"""\
         PyTrendy release {tag} ({'pre-release / develop' if is_prerelease else 'stable'}).
@@ -372,10 +379,10 @@ def _build_section(
         Omit the top-level ## heading — I will add it myself.
     """)
 
-    ai_content = _call_github_models(prompt, token)
+    ai_content = _call_opencode(prompt, model)
     if ai_content is None:
         print(
-            "[whats-new] Error: GitHub Models API call failed. See above for details. "
+            "[whats-new] Error: OpenCode call failed. See above for details. "
             "Failing the workflow rather than writing a low-quality fallback entry.",
             file=sys.stderr,
         )
@@ -644,7 +651,7 @@ def main() -> None:
     if not is_prerelease:
         _remove_prerelease_for_version_in_file(WHATS_NEW_PATH, _base_version(tag))
 
-    body = _build_section(tag, raw_notes, is_prerelease, token)
+    body = _build_section(tag, raw_notes, is_prerelease)
     heading = _make_heading(tag, is_prerelease, date_str)
     new_block = heading + "\n\n" + body
 

--- a/scripts/generate_whats_new.py
+++ b/scripts/generate_whats_new.py
@@ -75,6 +75,7 @@ DEFAULT_OPENCODE_MODEL = "opencode-go/kimi-k2.7-code"
 
 
 def _env(key: str, default: str = "") -> str:
+    """Return the value of environment variable ``key``, stripped, or ``default``."""
     return os.environ.get(key, default).strip()
 
 
@@ -103,6 +104,7 @@ def _target_prerelease_version(tag: str) -> str:
 
 
 def _major_minor(version: str) -> str:
+    """Return the ``major.minor`` prefix of a dotted version string."""
     parts = version.split(".")
     return ".".join(parts[:2]) if len(parts) >= 2 else version
 
@@ -391,6 +393,7 @@ def _build_section(
 
 
 def _make_heading(tag: str, is_prerelease: bool, date_str: str) -> str:
+    """Return the top-level Markdown heading for a release section."""
     base = _base_version(tag)
     if is_prerelease:
         target = _target_prerelease_version(tag)
@@ -627,6 +630,7 @@ def _upsert_prerelease_stream_section(file_path: Path, new_block: str, tag: str)
 
 
 def main() -> None:
+    """Generate or update the What's New documentation entry."""
     token = _env("GITHUB_TOKEN")
     tag = _env("RELEASE_TAG") or "v0.0.0"
     release_body = _env("RELEASE_BODY")


### PR DESCRIPTION
Migrates the What's New generator from the GitHub Models API to OpenCode (`opencode-go/kimi-k2.7-code`).

### Changes
- `scripts/generate_whats_new.py`
  - Replaced the GitHub Models API call with a subprocess invocation of `opencode run -m <model>`.
  - Added `OPENCODE_API_KEY` / `OPENCODE_MODEL` env-var handling.
  - Sets restrictive `OPENCODE_PERMISSION` defaults (no bash/edit/webfetch/websearch/external_directory/task access).
  - Fixed inconsistent model references in docstrings.
- `.github/workflows/whats-new.yaml`
  - Removed `models: read` permission.
  - Added OpenCode CLI install step (`curl -fsSL https://opencode.ai/install | bash`).
  - Passed `OPENCODE_API_KEY`, `OPENCODE_MODEL`, and `OPENCODE_PERMISSION` to generator steps.
  - Updated PR body text to mention OpenCode.
- `docs/whats-new.md`
  - Updated the v1.2.0 entry to say the generator uses OpenCode, with a parenthetical note that it previously used the GitHub Models API / GPT-4.1.

### Required repo setup
Add a repository secret named `OPENCODE_API_KEY` before the next release. Optionally add a repository variable `OPENCODE_MODEL` set to `opencode-go/kimi-k2.7-code`; if omitted, the workflow falls back to that default.

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated “What’s New” generator to use OpenCode (including the configured model and API key) for producing the next user-facing entry.
  * Updated the “Automated What’s New” documentation to reflect the new backend.
  * Tightened workflow job permissions to enhance security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->