### PR TITLE
ci(whats-new): add opencode bin to PATH before --version check

### DIFF
--- a/.github/workflows/whats-new.yaml
+++ b/.github/workflows/whats-new.yaml
@@ -148,6 +148,7 @@ jobs:
         if: steps.meta.outputs.skip != 'true'
         run: |
           curl -fsSL https://opencode.ai/install | bash
+          export PATH="$HOME/.opencode/bin:$PATH"
           opencode --version
 
       # ── 5. Run the agentic generator ────────────────────────────────────────
@@ -230,6 +231,7 @@ jobs:
       - name: Install OpenCode CLI
         run: |
           curl -fsSL https://opencode.ai/install | bash
+          export PATH="$HOME/.opencode/bin:$PATH"
           opencode --version
 
       - name: Re-generate What's New for develop (reframe as stable)

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/testtemp.py
 site/
 poetry.lock
 temp.csv
+.env


### PR DESCRIPTION
## What

Fixes the failing [What's New Generator workflow](https://github.com/RussellSB/pytrendy/actions/runs/28197500964/job/83528100066) — the "Install OpenCode CLI" step exits with code 127 (command not found).

## Why

The [opencode install script](https://opencode.ai/install) installs to `$HOME/.opencode/bin` and writes that path to `$GITHUB_PATH`. However, `GITHUB_PATH` only takes effect in **subsequent** workflow steps — not the current one. So `opencode --version` on the next line can't find the binary.

## Fix

Add `export PATH="$HOME/.opencode/bin:$PATH"` before `opencode --version` in both "Install OpenCode CLI" steps (`generate-whats-new` and `sync-to-develop` jobs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated release-note generation by ensuring the OpenCode CLI is available in all relevant workflow steps.
* **Chores**
  * Updated repository ignore rules to exclude `temp.csv` and `.env` from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->