### PR TITLE
ci(fix): correct whats-new model id from deepseek-flash-v4 to deepseek-v4-flash

### DIFF
--- a/.github/workflows/whats-new.yaml
+++ b/.github/workflows/whats-new.yaml
@@ -10,7 +10,7 @@ name: What's New Generator
 # ─────────────────────────────────────────────────────────────────────────────
 # • Resolve release metadata from release events, dispatch inputs, or the Release workflow run.
 # • Parse release notes (or fall back to CHANGELOG.md).
-# • Call OpenCode (opencode-go/deepseek-flash-v4) to generate a user-friendly entry.
+# • Call OpenCode (opencode-go/deepseek-v4-flash) to generate a user-friendly entry.
 # • Prepend the new entry into docs/whats-new.md.
 # • Open a PR back to the release branch (develop or main) for review.
 # • On main: also open a follow-up PR to sync the page back to develop.
@@ -156,7 +156,7 @@ jobs:
         if: steps.meta.outputs.skip != 'true'
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/deepseek-flash-v4' }}
+          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/deepseek-v4-flash' }}
           OPENCODE_PERMISSION: '{"bash": "deny", "edit": "deny", "webfetch": "deny", "websearch": "deny", "external_directory": "deny", "task": "deny"}'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.meta.outputs.tag }}
@@ -186,7 +186,7 @@ jobs:
 
             ### What changed
             - A new entry was prepended to `docs/whats-new.md` using **OpenCode**
-              (`opencode-go/deepseek-flash-v4`) to summarise the release notes in a user-friendly way.
+              (`opencode-go/deepseek-v4-flash`) to summarise the release notes in a user-friendly way.
 
             ### Review checklist
             - [ ] The generated content is accurate and user-friendly.
@@ -237,7 +237,7 @@ jobs:
       - name: Re-generate What's New for develop (reframe as stable)
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/deepseek-flash-v4' }}
+          OPENCODE_MODEL: ${{ vars.OPENCODE_MODEL || 'opencode-go/deepseek-v4-flash' }}
           OPENCODE_PERMISSION: '{"bash": "deny", "edit": "deny", "webfetch": "deny", "websearch": "deny", "external_directory": "deny", "task": "deny"}'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.generate-whats-new.outputs.tag }}

--- a/.opencode/skills/cicd/SKILL.md
+++ b/.opencode/skills/cicd/SKILL.md
@@ -53,7 +53,7 @@ Triggers: on release publish, on Release workflow completion (main/develop), or 
 
 1. Resolves release metadata (tag, name, body, prerelease flag, branch) from the event payload, falling back to the GitHub Releases API by tag, then `CHANGELOG.md`.
 2. Checks out the release branch, installs the **OpenCode CLI** (see `whats-new.yaml` for the exact install step).
-3. Runs `python scripts/generate_whats_new.py` with `OPENCODE_MODEL` (default `opencode-go/deepseek-flash-v4`) and a **deny-all permission block** (`bash/edit/webfetch/websearch/external_directory/task` all `deny`) — the agent can only read and write the whats-new file via the script.
+3. Runs `python scripts/generate_whats_new.py` with `OPENCODE_MODEL` (default `opencode-go/deepseek-v4-flash`) and a **deny-all permission block** (`bash/edit/webfetch/websearch/external_directory/task` all `deny`) — the agent can only read and write the whats-new file via the script.
 4. The script prepends a user-friendly entry into `docs/whats-new.md` **between sentinel comments** `<!-- WHATS_NEW_CONTENT_START -->` / `<!-- WHATS_NEW_CONTENT_END -->`. Don't edit content inside those markers by hand — it gets regenerated.
 5. Opens a PR (`docs/whats-new-<tag>`) back to the release branch via `peter-evans/create-pull-request@v7` using `DOCS_PREVIEW_PAT`. The PR's `base` is the release branch (develop or main) — these are the *only* PRs allowed to target `main` from a non-`develop` head (`check-base-branch.yml` whitelists `docs/whats-new-*`).
 6. On stable releases (main, not prerelease), a `sync-to-develop` job re-generates the entry framed as stable and opens a follow-up PR to `develop` so both branches stay consistent.

--- a/scripts/generate_whats_new.py
+++ b/scripts/generate_whats_new.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Generate or update docs/whats-new.md using OpenCode (opencode-go/deepseek-flash-v4).
+"""Generate or update docs/whats-new.md using OpenCode (opencode-go/deepseek-v4-flash).
 
 The script:
   1. Reads the latest release notes (from RELEASE_BODY, then GitHub Releases API by
      tag, then CHANGELOG.md).
-  2. Calls OpenCode (opencode-go/deepseek-flash-v4) to produce a user-friendly
+  2. Calls OpenCode (opencode-go/deepseek-v4-flash) to produce a user-friendly
      What's New section in MkDocs-compatible Markdown.
   3. Prepends the new section into docs/whats-new.md between the sentinel
      comment markers, preserving the rest of the file.
@@ -29,7 +29,7 @@ Environment variables
 ---------------------
 OPENCODE_API_KEY – required; authenticates against the OpenCode API.
 OPENCODE_MODEL   – optional; model ID passed to `opencode run` (default:
-                   "opencode-go/deepseek-flash-v4").
+                   "opencode-go/deepseek-v4-flash").
 GITHUB_TOKEN     – required; used for the GitHub Releases API fallback and by the
                    workflow to open pull requests.
 RELEASE_TAG      – the semantic-release tag (e.g. "v1.2.0" or "v1.2.0-dev.1").
@@ -67,7 +67,7 @@ CONTENT_END = "<!-- WHATS_NEW_CONTENT_END -->"
 NOTE_START = "<!-- WHATS_NEW_NOTE_START -->"
 NOTE_END = "<!-- WHATS_NEW_NOTE_END -->"
 
-DEFAULT_OPENCODE_MODEL = "opencode-go/deepseek-flash-v4"
+DEFAULT_OPENCODE_MODEL = "opencode-go/deepseek-v4-flash"
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

Corrects the OpenCode model ID in the whats-new generator from `deepseek-flash-v4` to `deepseek-v4-flash`.

## Changes

- Fixed model ID in `scripts/generate_whats_new.py` (default constant and docstrings)
- Fixed model ID in `.github/workflows/whats-new.yaml` (generate-whats-new and sync-to-develop jobs)
- Fixed model ID in `.opencode/skills/cicd/SKILL.md` (documentation)

## Why

The model ID was incorrect after PR #174, causing the whats-new generator to fail when trying to use a non-existent model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AI model used by the “What’s New” generation workflow and script.
  * Aligned the related workflow guidance and generated PR text with the new default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->