### PR TITLE
ci: add issues and pull-requests write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
+      pull-requests: write
     outputs:
       released: ${{ steps.release.outputs.released }}
     steps:


### PR DESCRIPTION
## Summary

Add `issues: write` and `pull-requests: write` permissions to the `semantic-release` job in `release.yaml`.

## Why

The `@semantic-release/github` plugin needs these permissions to:
- **Comment on released issues** with "🎉 This issue has been resolved in version X.Y.Z"
- **Add `released` labels** to issues and PRs included in a release
- **Comment on released PRs** linking them to the GitHub release

Currently missing, so semantic-release silently skips all issue/PR interactions on main releases.

## How this works with your workflow

With **GitHub linked issues** (link via the PR Development sidebar), issues auto-close when merged to develop. On main releases, semantic-release will now also comment and label — giving a clear "released" trail on fixed issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions to support broader GitHub interactions during publishing.
  * Improved the release process with additional access for issue and pull request updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->