### PR TITLE
ci: update opencode job conditions and permissions 

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,10 +9,15 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      (
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      ) && (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -20,9 +20,13 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      # OIDC token for OpenCode auth
       id-token: write
+      # read-only checkout of repository code
       contents: read
+      # allows OpenCode to comment on / update PRs it's invoked from
       pull-requests: write
+      # allows OpenCode to comment on / update issues it's invoked from
       issues: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updates opencode permissions so that it can create PRs & issues.
Restricting access to owner/collaborator so that random malicious online peeps can't use it to cause chaos.

Plan is to merge this first to develop -> main. So repo wide settings update.
Then Chris M should be able to do what he wants to do in PR #205 