### PR TITLE
ci: use GITHUB_TOKEN for OpenCode PR creation

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode-go/mimo-v2.5
           use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -40,3 +40,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           model: opencode-go/mimo-v2.5
+          use_github_token: true


### PR DESCRIPTION
## Summary

Add `use_github_token: true` to the OpenCode workflow so it uses the workflow's `GITHUB_TOKEN` instead of the OpenCode GitHub App's installation token.

## Problem

OpenCode was using the default OpenCode GitHub App installation token, which didn't have PR creation permissions on this repository. This caused branches to be created but no PRs to be opened.

## Solution

By setting `use_github_token: true`, OpenCode now uses the workflow's `GITHUB_TOKEN` with the permissions we've already granted:
- `contents: write` — push branches and commits
- `pull-requests: write` — create PRs
- `issues: write` — comment on issues

## Reference

- [OpenCode GitHub Docs](https://opencode.ai/docs/github/#configuration)
- Related: #205, #207