### PR TITLE
chore: serialise gh-pages pushes to prevent docs-preview race condition

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -18,8 +18,8 @@ on:
       - 'pytrendy/**'
 
 concurrency:
-  group: docs-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy-preview:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: gh-pages-deploy
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
This PR fixes a race condition where multiple docs-preview workflows running concurrently would fail when pushing to the shared `gh-pages` branch.

**Problem:** When multiple PRs are updated simultaneously, each triggers a docs-preview workflow that builds and deploys to `gh-pages`. Only the first push succeeds; subsequent pushes fail with `git exit code 1` because the remote branch has moved.

**Solution:** Add a shared concurrency group `gh-pages-deploy` to both `docs-preview.yaml` and `docs.yaml`, serializing all pushes to `gh-pages`. With `cancel-in-progress: false`, queued runs complete rather than being cancelled.

**Tradeoff:** Simultaneous PR updates will queue their docs deployments sequentially instead of racing. Each individual run succeeds reliably.