### PR TITLE
ci: align opencode workflow with official docs

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -38,7 +38,5 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode-go/mimo-v2.5
-          use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -23,7 +23,8 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        # TODO: upgrade to @v7 when opencode docs update
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -20,14 +20,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      # OIDC token for OpenCode auth
       id-token: write
-      # allows OpenCode to push branches, commits, and create PRs
-      contents: write
-      # allows OpenCode to comment on / update PRs it's invoked from
-      pull-requests: write
-      # allows OpenCode to comment on / update issues it's invoked from
-      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Fixes opencode GitHub Actions workflow that was failing on `main` when triggered via `/oc` comments on PRs.

**Root cause:** Two failed runs (#29319605862, #29328339090) showed:
1. "Author identity unknown" — git config missing `user.email`/`user.name`
2. "could not read Username for 'https://github.com'" — git auth failed

**Fix:** Align workflow with [official opencode docs](https://opencode.ai/docs/github/):

| Change | Why |
|--------|-----|
| Remove `GITHUB_TOKEN` env var | App handles auth via OIDC |
| Remove `use_github_token: true` | App's installation token is the default auth path |
| Trim permissions to `id-token: write` only | Extra permissions only needed for GITHUB_TOKEN path |
| Downgrade `checkout@v7` → `@v6` | Matches all opencode doc examples |

**Note:** This PR targets `main` directly because `issue_comment` triggers only read workflow files from the default branch.