### PR TITLE
ci: harden remote OC agent config

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -31,10 +31,44 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure opencode for CI
+        run: |
+          mkdir -p ~/.config/opencode
+          cat > ~/.config/opencode/opencode.jsonc << 'EOCONF'
+          {
+            "plugin": [
+              "@dietrichgebert/ponytail"
+            ],
+            "mcp": {
+              "github": {
+                "type": "remote",
+                "url": "https://api.githubcopilot.com/mcp/",
+                "headers": {
+                  "Authorization": "Bearer $GITHUB_PERSONAL_ACCESS_TOKEN"
+                }
+              },
+              "gh_grep": {
+                "type": "remote",
+                "url": "https://mcp.grep.app"
+              },
+              "context7": {
+                "type": "remote",
+                "url": "https://mcp.context7.com/mcp",
+                "headers": {
+                  "Authorization": "Bearer $CONTEXT7_API_KEY"
+                }
+              }
+            }
+          }
+          EOCONF
+
       - name: Run opencode
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           PYTRENDY_CI: "true"
+          PONYTAIL_DEFAULT_MODE: "ultra"
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
         with:
           model: opencode-go/mimo-v2.5

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,6 +19,7 @@ jobs:
         startsWith(github.event.comment.body, '/opencode')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: write
@@ -44,6 +45,11 @@ jobs:
             "plugin": [
               "@dietrichgebert/ponytail"
             ],
+            "permission": {
+              "external_directory": {
+                "/tmp/*": "allow"
+              }
+            },
             "mcp": {
               "github": {
                 "type": "remote",

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Create a CI-specific global config instead of modifying the project's
+      # opencode.json to avoid conflicts with local dev setups. Plugins are
+      # deduplicated by package name, but the user's global config has a local
+      # ponytail plugin file that would coexist with the npm package — creating
+      # a CI-only config sidesteps this entirely.
       - name: Configure opencode for CI
         run: |
           mkdir -p ~/.config/opencode

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -5,18 +5,26 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   opencode:
     if: |
       (
         github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'OWNER'
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.review.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'OWNER'
       ) && (
         contains(github.event.comment.body, ' /oc') ||
         startsWith(github.event.comment.body, '/oc') ||
         contains(github.event.comment.body, ' /opencode') ||
-        startsWith(github.event.comment.body, '/opencode')
+        startsWith(github.event.comment.body, '/opencode') ||
+        contains(github.event.review.body, ' /oc') ||
+        startsWith(github.event.review.body, '/oc') ||
+        contains(github.event.review.body, ' /opencode') ||
+        startsWith(github.event.review.body, '/opencode')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -48,7 +48,9 @@ jobs:
             "permission": {
               "external_directory": {
                 "/tmp/*": "allow"
-              }
+              },
+              "question": "deny",
+              "doom_loop": "deny"
             },
             "mcp": {
               "github": {

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -61,13 +61,6 @@ jobs:
               "doom_loop": "deny"
             },
             "mcp": {
-              "github": {
-                "type": "remote",
-                "url": "https://api.githubcopilot.com/mcp/",
-                "headers": {
-                  "Authorization": "Bearer $GITHUB_PERSONAL_ACCESS_TOKEN"
-                }
-              },
               "gh_grep": {
                 "type": "remote",
                 "url": "https://mcp.grep.app"
@@ -76,7 +69,7 @@ jobs:
                 "type": "remote",
                 "url": "https://mcp.context7.com/mcp",
                 "headers": {
-                  "Authorization": "Bearer $CONTEXT7_API_KEY"
+                  "Authorization": "Bearer {env:CONTEXT7_API_KEY}"
                 }
               }
             }
@@ -89,7 +82,6 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           PYTRENDY_CI: "true"
           PONYTAIL_DEFAULT_MODE: "ultra"
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
         with:
           model: opencode-go/mimo-v2.5


### PR DESCRIPTION
Closes #248, closes #279

The remote opencode agent (triggered by `/oc`) was bare-bones — no plugins, no MCP servers, no timeout, and a broken review-body trigger. This PR brings it up to parity with the local setup while fixing two known bugs.

## What changed

**New capabilities** (`.github/workflows/opencode.yml`):
- **Ponytail** (`ultra` mode) — enforces YAGNI, prevents over-engineering in PR reviews
- **MCP servers** — gh_grep (code pattern search), context7 (docs lookup)
- **CI-specific global config** — avoids conflicts with local dev setups by writing `~/.config/opencode/opencode.jsonc` at runtime instead of modifying the project's `opencode.json`

**Reliability fixes**:
- `timeout-minutes: 15` — caps runaway jobs (previously defaulted to 6 hours)
- `external_directory` auto-allows `/tmp/*` — the agent writes temp plot images here; without this it blocked on an interactive permission prompt
- `question` and `doom_loop` denied — both default to `ask`, which hangs in CI with no human to respond
- `pull_request_review` (submitted) trigger — `/oc` in a review body ("Finish your review" dialog) now fires the agent. Previously only PR thread comments and line-level review comments worked

**Removed**:
- GitHub MCP server — redundant with the OpenCode GitHub App's built-in GitHub tools

## Local dev impact

None. The project's `opencode.json` is untouched — it still only contains `instructions`. The CI config is created at runtime in `~/.config/opencode/`, so there are no duplicates with your local global config.

## Trigger points

| Where you write `/oc` | Event type | Works? |
|---|---|---|
| PR thread comment | `issue_comment` | ✅ (already worked) |
| Diff line comment | `pull_request_review_comment` | ✅ (already worked) |
| Review body dialog | `pull_request_review` | ✅ **new** |

## Deferred

AFT and Magic Context were considered but excluded — the built-in opencode tools handle most PR tasks, and the skills system already provides durable knowledge for CI. Both can be added later if the agent feels limited.

## Setup required

- [x] Add `CONTEXT7_API_KEY` as a repo secret
- [x] Cancel the hung run: `gh run cancel 29647397536 --repo RussellSB/pytrendy`