### PR TITLE
fix(plot): honor grid and legend parameters

### DIFF
--- a/pytrendy/detect_trends.py
+++ b/pytrendy/detect_trends.py
@@ -44,6 +44,7 @@ def detect_trends(df: pd.DataFrame, date_col: str, value_col: str, plot=True, me
             - **avoid_noise** (`bool`): Whether to avoid noisy segments in trend detection. Defaults to `True`.
         plot_params (dict, optional):
             Optional dict to customise plot appearance. Only used when `plot` is `True`. Supported keys:
+
             - **figsize** (`tuple`): Figure size as (width, height). Defaults to (20, 5).
             - **title** (`str`): Plot title. Defaults to "PyTrendy Detection".
             - **xlabel** (`str`): X-axis label. Defaults to "Date".

--- a/pytrendy/io/plot_pytrendy.py
+++ b/pytrendy/io/plot_pytrendy.py
@@ -23,6 +23,7 @@ def plot_pytrendy(df: pd.DataFrame, value_col: str, segments_enhanced: list[dict
             If True, suppresses the automatic display of the plot with plt.show(). Defaults to False.
         plot_params (dict, optional):
             Optional dict to customise plot appearance. Supported keys:
+
             - **figsize** (`tuple`): Figure size as (width, height). Defaults to (20, 5).
             - **title** (`str`): Plot title. Defaults to "PyTrendy Detection".
             - **xlabel** (`str`): X-axis label. Defaults to "Date".
@@ -57,6 +58,8 @@ def plot_pytrendy(df: pd.DataFrame, value_col: str, segments_enhanced: list[dict
     }
     if plot_params:
         plot_params = dict(plot_params)  # avoid mutating caller's dict
+        has_custom_legend_loc = 'legend_loc' in plot_params
+        has_custom_legend_anchor = 'legend_bbox_to_anchor' in plot_params
         custom_colors = plot_params.pop('colors', None)
         custom_grid = plot_params.pop('grid', None)
         default_params.update(plot_params)
@@ -64,6 +67,8 @@ def plot_pytrendy(df: pd.DataFrame, value_col: str, segments_enhanced: list[dict
             default_params['colors'].update(custom_colors)
         if custom_grid:
             default_params['grid'].update(custom_grid)
+        if has_custom_legend_loc and not has_custom_legend_anchor:
+            default_params['legend_bbox_to_anchor'] = None
 
     # Define colors
     color_map = default_params['colors']
@@ -173,7 +178,11 @@ def plot_pytrendy(df: pd.DataFrame, value_col: str, segments_enhanced: list[dict
     plt.setp(ax.get_xticklabels(), rotation=90, ha='right')
 
     # Optional: show grid lines for both
-    ax.grid(default_params['grid']['visible'], **{k: v for k, v in default_params['grid'].items() if k != 'visible'})
+    grid_params = default_params['grid']
+    if grid_params['visible']:
+        ax.grid(True, **{k: v for k, v in grid_params.items() if k != 'visible'})
+    else:
+        ax.grid(False, which='both')
 
     ax.set_title(default_params['title'], fontsize=20)
     ax.set_xlabel(default_params['xlabel'])

--- a/tests/tests_plotting/core/test_plot_pytrendy_core.py
+++ b/tests/tests_plotting/core/test_plot_pytrendy_core.py
@@ -76,9 +76,50 @@ class TestPlotPytrendyCore:
         """Test visualisation with custom plot_params."""
         df = pt.load_data('series_synthetic')
         results = pt.detect_trends(df, date_col='date', value_col='gradual', plot=False)
-        custom_params = {'figsize': (10, 4), 'title': 'Custom Title', 'colors': {'Up': 'lightpink'}, 'grid': {'visible': False, 'which': 'minor', 'color': 'red', 'alpha': 0.8}}
+        custom_params = {
+            'figsize': (10, 4),
+            'title': 'Custom Title',
+            'colors': {'Up': 'lightpink'},
+            'grid': {'visible': False, 'which': 'minor', 'color': 'red', 'alpha': 0.8},
+            'legend_loc': 'upper left',
+        }
         fig = self._prepare_and_plot(df, 'gradual', results.segments, plot_params=custom_params)
+        ax = fig.axes[0]
         assert fig.get_size_inches()[0] == 10
-        assert fig.axes[0].get_title() == 'Custom Title'
-        assert fig.axes[0].xaxis.get_major_locator() is not None
+        assert ax.get_title() == 'Custom Title'
+        assert ax.xaxis.get_major_locator() is not None
+        gridlines = [
+            tick.gridline
+            for axis in (ax.xaxis, ax.yaxis)
+            for tick in (*axis.get_major_ticks(), *axis.get_minor_ticks())
+        ]
+        assert not any(line.get_visible() for line in gridlines)
+
+        fig.canvas.draw()
+        legend = ax.get_legend()
+        assert legend is not None
+        legend_box = legend.get_window_extent()
+        axes_box = ax.get_window_extent()
+        assert legend_box.x0 >= axes_box.x0
+        assert legend_box.y1 <= axes_box.y1
+
+        anchored_fig = self._prepare_and_plot(
+            df,
+            'gradual',
+            results.segments,
+            plot_params={
+                'legend_loc': 'lower left',
+                'legend_bbox_to_anchor': (0.5, 0.5),
+            },
+        )
+        anchored_legend = anchored_fig.axes[0].get_legend()
+        assert anchored_legend is not None
+        anchor_point = tuple(
+            anchored_legend.get_bbox_to_anchor().get_points()[0]
+        )
+        expected_anchor = tuple(
+            anchored_fig.axes[0].transAxes.transform((0.5, 0.5))
+        )
+        assert anchor_point == pytest.approx(expected_anchor)
         plt.close(fig)
+        plt.close(anchored_fig)


### PR DESCRIPTION
Closes #250

`grid.visible=False` no longer passes style kwargs that make Matplotlib turn the grid back on. A custom `legend_loc` now uses Matplotlib's natural anchor unless `legend_bbox_to_anchor` is supplied explicitly, and the plot-parameter lists render correctly in the API docs.

Tested with the full suite: 101 passed. The focused regression fails on the original plotting code and passes with this change.