### PR TITLE
ci: resolve issue creation, tighten functional /oc body gate, and add concurrency for OC agent

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,9 +19,17 @@ on:
 
 jobs:
   opencode:
+    concurrency:
+      group: opencode-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     if: |
-      github.event.comment.author_association == 'COLLABORATOR' ||
-      github.event.comment.author_association == 'OWNER'
+      (
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      ) && (
+        contains(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,31 +1,27 @@
 name: opencode
 
+# Supported events (per opencode docs + runtime allowlist):
+#   issue_comment              — /oc in PR/issue conversation thread
+#   pull_request_review_comment — /oc on a specific code line (Files tab)
+#   issues                     — auto on issue open/edit (needs prompt input)
+#   pull_request               — auto on PR open/sync (needs prompt input)
+#   schedule                   — cron (needs prompt input)
+#   workflow_dispatch           — manual (needs prompt input)
+#
+# Note: pull_request_review (review body on Submit) is NOT supported by the
+# opencode action. /oc in review bodies will be ignored. Use conversation
+# comments or line comments instead.
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   opencode:
     if: |
-      (
-        github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.review.author_association == 'COLLABORATOR' ||
-        github.event.review.author_association == 'OWNER'
-      ) && (
-        contains(github.event.comment.body, ' /oc') ||
-        startsWith(github.event.comment.body, '/oc') ||
-        contains(github.event.comment.body, ' /opencode') ||
-        startsWith(github.event.comment.body, '/opencode') ||
-        contains(github.event.review.body, ' /oc') ||
-        startsWith(github.event.review.body, '/oc') ||
-        contains(github.event.review.body, ' /opencode') ||
-        startsWith(github.event.review.body, '/opencode')
-      )
+      github.event.comment.author_association == 'COLLABORATOR' ||
+      github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -83,5 +79,6 @@ jobs:
           PYTRENDY_CI: "true"
           PONYTAIL_DEFAULT_MODE: "ultra"
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode-go/mimo-v2.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ Other skills (`test`, `cicd`, `debug`, `pr-plots`) load on demand for specific t
 ## Critical rules (summary — details in skills)
 
 - PRs target `develop`, not `main`
-- Commits: Conventional Commits enforced by `lint-pr-title.yml`
+- **Commits must use Conventional Commits**: `fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `revert:`
+  - Lowercase, imperative, <72 chars, no trailing period
+  - This applies to all commit messages you generate, including auto-generated summaries
+  - `lint-pr-title.yml` enforces this on PR titles
 - Deprecating a public param = `feat:` (minor), NOT `refactor:`
 - Never hand-edit `pyproject.toml` version or `CHANGELOG.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,6 @@ Other skills (`test`, `cicd`, `debug`, `pr-plots`) load on demand for specific t
 - **Commits must use Conventional Commits**: `fix:`, `feat:`, `chore:`, `ci:`, `docs:`, `refactor:`, `perf:`, `test:`, `build:`, `revert:`
   - Lowercase, imperative, <72 chars, no trailing period
   - This applies to all commit messages you generate, including auto-generated summaries
-  - `lint-pr-title.yml` enforces this on PR titles
+  - `lint-pr-title.yml` enforces the `type: description` prefix and allowed types on PR titles (regex: `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+`)
 - Deprecating a public param = `feat:` (minor), NOT `refactor:`
 - Never hand-edit `pyproject.toml` version or `CHANGELOG.md`


### PR DESCRIPTION
## Changes

### `opencode.yml`

**`GH_TOKEN` for `gh` CLI auth** (#251): Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the opencode workflow env. The action uses Octokit for its own GitHub operations, but when the agent shells out to `gh` CLI via the bash tool, it needs `GH_TOKEN` in the environment. The workflow's `permissions:` block already grants `issues: write`.

**Remove unsupported `pull_request_review` trigger** (#252): The opencode action runtime (`github.handler.ts:148`) only supports `issue_comment`, `pull_request_review_comment`, `issues`, `pull_request`, `schedule`, `workflow_dispatch`. `/oc` in a review body (`pull_request_review`) throws `Unsupported event type`. Removed the trigger and added a comment block documenting the supported events. Conversation comments and line comments still work.

**Restore `/oc` body gate**: The `if` condition now checks `github.event.comment.body` for `/oc` or `/opencode`, so ordinary discussion comments don't reach the agent.

**Concurrency group**: Added `concurrency` keyed by issue/PR number with `cancel-in-progress: false` to serialise agent runs per discussion and avoid race conditions on rapid comments.

### `AGENTS.md`

**Conventional Commits enforcement** (#253): Expanded the Critical rules section with explicit commit conventions so the agent applies them without needing to load the maintenance skill first. Narrowed the `lint-pr-title.yml` claim to what it actually enforces: the `type: description` prefix and allowed types on PR titles.

## Supported events

| Event | Trigger | Notes |
|---|---|---|
| `issue_comment` | `/oc` or `/opencode` in PR/issue conversation | Works |
| `pull_request_review_comment` | `/oc` or `/opencode` on a code line (Files tab) | Works |
| `pull_request_review` | `/oc` or `/opencode` in review body (Submit review) | **Not supported** — [upstream issue](https://github.com/anomalyco/opencode/issues/2152) |

Closes #251
Closes #252
Closes #253