### PR TITLE
ci: replace gh pr diff with gh api for CI/CD bypass in check-base-branch

### DIFF
--- a/.github/workflows/check-base-branch.yml
+++ b/.github/workflows/check-base-branch.yml
@@ -42,7 +42,8 @@ jobs:
           if [ "$BASE" = "main" ]; then
             # Check if all changed files are CI/CD or agentic config files
             PR_NUMBER=$(jq --raw-output '.pull_request.number // empty' "$GITHUB_EVENT_PATH")
-            CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
+            REPO="${{ github.repository }}"
+            CHANGED_FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null || echo "")
             if [ -n "$CHANGED_FILES" ]; then
               NON_CICD_FILES=$(echo "$CHANGED_FILES" | grep -v -E "^(.github/|AGENTS\.md$|pyproject\.toml$|opencode\.json$|opencode\.yaml$|\.opencode/|\.releaserc)" || true)
               if [ -z "$NON_CICD_FILES" ]; then


### PR DESCRIPTION
Closes #274

## Problem

The CI/CD-only bypass in `check-base-branch.yml` silently fails because `gh pr diff` requires local git context (a checkout step) that this workflow doesn't have. The `2>/dev/null || echo ""` swallows the error, producing empty `CHANGED_FILES` — which skips the bypass and falls through to the hard error.

**Failed run:** [PR #273](https://github.com/RussellSB/pytrendy/actions/runs/30902488071) (only changed `.github/workflows/opencode.yml`)

### Root cause (from `gh` CLI source)

`gh pr diff` → `finder.Find()` → `BaseRepoFunc` → `remotesFunc()` → `git remote -v`. Without `actions/checkout`, there's no git repository, so `gh` can't determine which repo to query. The error is silently swallowed.

Other projects hit this too:
- **grafana/mimir** switched to the REST API because `gh pr diff` "caps at 300 files and returns HTTP 406 on larger PRs"
- **RocketChat** uses `gh pr diff` but passes `--repo "${GITHUB_REPOSITORY}"` explicitly

## Fix

Replace `gh pr diff` with `gh api` — the REST API endpoint `GET /repos/{owner}/{repo}/pulls/{number}/files` works without git context, needs only `pull-requests: read` (already granted), and handles pagination.

```diff
- CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
+ REPO="${{ github.repository }}"
+ CHANGED_FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null || echo "")
```
