### PR TITLE
chore(ci): use repo variable for opencode model with deepseek-v4-flash default

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -89,4 +89,4 @@ jobs:
           CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode-go/mimo-v2.5
+          model: ${{ vars.OPENCODE_MODEL || 'opencode-go/deepseek-v4-flash' }}


### PR DESCRIPTION
Replaces the hardcoded `opencode-go/mimo-v2.5` model with a `vars.OPENCODE_MODEL` repository variable, falling back to `opencode-go/deepseek-v4-flash` when unset.