### PR TITLE
refactor: remove dead code in has_overlap_next and has_overlap_prev

### DIFF
--- a/pytrendy/post_processing/segments_refine/artifact_cleanup.py
+++ b/pytrendy/post_processing/segments_refine/artifact_cleanup.py
@@ -59,30 +59,15 @@ def clean_artifacts(df: pd.DataFrame, value_col: str, segments_refined: list[dic
         dir = segment['direction']
         start =  pd.to_datetime(segment['start'])
         end =  pd.to_datetime(segment['end'])
-        width = (end - start).days
 
-        next_dir = segment_next['direction']
         next_start = pd.to_datetime(segment_next['start'])
-        next_end = pd.to_datetime(segment_next['end'])
-        next_width = (next_end - next_start).days
+        next_dir = segment_next['direction']
 
-        # Define conditions # TODO: Cleanup redunant condition statements no longer used.
         is_overlap_next = (end >= next_start)
         is_same_dir = (dir == next_dir)
-        is_curr_shorter = (width <= next_width)
-        is_curr_similar = (next_width <= 1.5 * width) and (next_width >= 0.5 * width)
 
-        is_trend = (dir in ('Up', 'Down'))
-        is_next_noise = (next_dir == 'Noise')
-        is_next_opposite_trend = (next_dir in ('Up', 'Down') and next_dir != dir)
-        is_next_flat = (next_dir == 'Flat')
-
-        is_next_gradual = ('trend_class' in segment_next and segment_next['trend_class'] == 'gradual')
-        is_next_abrupt = ('trend_class' in segment_next and segment_next['trend_class'] == 'abrupt')
-
-        # Trigger edge cases of overlap if satisfied
         if is_overlap_next and is_same_dir:
-            return True # overlap when same direction, and is same dir
+            return True
 
         return False
     
@@ -98,20 +83,15 @@ def clean_artifacts(df: pd.DataFrame, value_col: str, segments_refined: list[dic
         prev_end = pd.to_datetime(segment_prev['end'])
         prev_width = (prev_end - prev_start).days
 
-        # Define conditions # TODO: Cleanup redunant condition statements no longer used.
         is_overlap_prev = (start <= prev_end)
         is_curr_shorter = (width <= prev_width)
-        is_curr_similar = (prev_width <= 1.5 * width) and (prev_width >= 0.5 * width)
-
         is_trend = (dir in ('Up', 'Down'))
         is_prev_noise = (prev_dir == 'Noise')
         is_prev_opposite_trend = (prev_dir in ('Up', 'Down') and prev_dir != dir)
-        is_prev_flat = (prev_dir == 'Flat')
 
         if is_overlap_prev and (is_trend and (is_prev_noise or is_prev_opposite_trend) and is_curr_shorter):
-            return True # overlap when curr is trend and prev is noise of larger/equal window
-        if is_overlap_prev and (is_trend and is_prev_flat) and is_curr_similar:
-            return True # overlap when curr is trend and prev is flat (with similar enough size), edge case scenario 11
+            return True
+
         return False
     
     def has_partial_overlap_next(segment: dict, segment_next: dict) -> bool:


### PR DESCRIPTION
## Summary
Removes unreachable code branches in `artifact_cleanup.py` identified in #279.

## Changes
- **`has_overlap_next`**: Removed 8 unused variables and a TODO comment. Function now only checks `is_overlap_next and is_same_dir`.
- **`has_overlap_prev`**: Removed the dead branch for `is_prev_flat` and unused variables.

## Why
These branches were added in PR #46 but are never triggered. The pipeline produces non-overlapping segments, so these overlap conditions are never met. Coverage confirmed lines 113-114 are never executed.

## Testing
- All 102 tests pass
- Coverage: 99%

Closes #279